### PR TITLE
Spread currentOps to ensure we keep all mocked operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ Cypress.Commands.add(
     cy.wrap({
       setOperations: (newOperations: Partial<AllOperations>) => {
         currentOps = {
-          ...(operations as object),
+          ...currentOps,
           ...(newOperations as object)
         };
       }


### PR DESCRIPTION
Currently when you call `mockGraphqlOps` with a third operation, it will keep the first & last but drop the one in the middle. This PR spreads `currentOps` instead of `operations` to ensure it keeps all mocked operations.