### PR TITLE
Add support for batched & persisted queries.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ interface SetOperationsOpts<AllOperations> {
 interface GQLRequestPayload<AllOperations extends Record<string, any>> {
   operationName: Extract<keyof AllOperations, string>;
   query: string;
+  extensions?: { persistedQuery: any };
   variables: any;
 }
 
@@ -121,6 +122,14 @@ Cypress.Commands.add(
           return Promise.resolve({
             data: {},
             errors: [rootValue]
+          });
+        }
+
+        // If using apollo-link-persisted-queries, return an error so that Apollo
+        // Client will retry as a standard GraphQL query <https://git.io/fjV9B>:
+        if (payload.extensions && payload.extensions.persistedQuery) {
+          return Promise.resolve({
+            errors: [{ message: "PersistedQueryNotSupported" }]
           });
         }
 

--- a/test/cypress/integration/resolvers.spec.ts
+++ b/test/cypress/integration/resolvers.spec.ts
@@ -66,5 +66,31 @@ describe("Resolvers", () => {
     cy.get("#tester").contains('Loading...')
     cy.wait(2000)
     cy.get("#tester").should('not.contain', 'Loading...')
-  })
+  });
+
+
+  it("Should rerequest persisted queries", () => {
+    cy.on('window:before:load', window => window.__USE_PERSISTED_QUERY_LINK = true);
+
+    cy.mockGraphqlOps({
+      operations: {
+        getUser: {
+          user: {
+            id: 1,
+            name: "Name",
+            email: "Email"
+          }
+        }
+      }
+    });
+
+    cy.visit("/");
+    cy.get("#GET_USER").click();
+    cy.get("#data").should(
+      "contain",
+      JSON.stringify({
+        user: { id: 1, name: "Name", email: "Email", __typename: "User" }
+      })
+    );
+  });
 });

--- a/test/cypress/integration/resolvers.spec.ts
+++ b/test/cypress/integration/resolvers.spec.ts
@@ -22,7 +22,7 @@ describe("Resolvers", () => {
 
     cy.visit("/");
     cy.get("#GET_USER").click();
-    cy.get("#data").should(
+    cy.get("#GET_USER_RESULT").should(
       "contain",
       JSON.stringify({
         user: { id: 1, name: "Name", email: "Email", __typename: "User" }
@@ -86,11 +86,47 @@ describe("Resolvers", () => {
 
     cy.visit("/");
     cy.get("#GET_USER").click();
-    cy.get("#data").should(
+    cy.get("#GET_USER_RESULT").should(
       "contain",
       JSON.stringify({
         user: { id: 1, name: "Name", email: "Email", __typename: "User" }
       })
     );
+  });
+
+  it("Should handle batched queries", () => {
+    cy.on('window:before:load', window => window.__USE_BATCH_HTTP_LINK = true);
+
+    cy.mockGraphqlOps({
+      operations: {
+        getUser: {
+          user: {
+            id: 1,
+            name: "Name",
+            email: "Email"
+          }
+        },
+        getRecipe: {
+          recipe: {
+            id: 1,
+            title: "Pancakes",
+            ingredients: "Flour, baking soda, salt, egg, milk",
+          }
+        }
+      }
+    });
+
+    cy.visit("/");
+    cy.get("#MULTIPLE").click();
+
+    cy.get("#GET_USER_RESULT")
+      .should("contain", JSON.stringify({
+        user: { id: 1, name: "Name", email: "Email", __typename: "User" }
+      }));
+
+    cy.get("#GET_RECIPE_RESULT")
+      .should("contain", JSON.stringify({
+        recipe: { id: 1, title: "Pancakes", ingredients: "Flour, baking soda, salt, egg, milk", __typename: "Recipe" }
+      }));
   });
 });

--- a/test/test-graphql-app/package.json
+++ b/test/test-graphql-app/package.json
@@ -7,6 +7,7 @@
     "@material-ui/lab": "^4.0.0-alpha.23",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
+    "apollo-link-batch-http": "^1.2.12",
     "apollo-link-http": "^1.5.15",
     "apollo-link-persisted-queries": "^0.2.2",
     "graphql": "^14.4.2",

--- a/test/test-graphql-app/package.json
+++ b/test/test-graphql-app/package.json
@@ -5,8 +5,12 @@
   "dependencies": {
     "@material-ui/core": "^4.3.2",
     "@material-ui/lab": "^4.0.0-alpha.23",
-    "apollo-boost": "^0.4.4",
+    "apollo-cache-inmemory": "^1.6.3",
+    "apollo-client": "^2.6.4",
+    "apollo-link-http": "^1.5.15",
+    "apollo-link-persisted-queries": "^0.2.2",
     "graphql": "^14.4.2",
+    "graphql-tag": "^2.10.1",
     "react": "^16.9.0",
     "react-apollo": "^3.0.1",
     "react-dom": "^16.9.0",

--- a/test/test-graphql-app/src/App.js
+++ b/test/test-graphql-app/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { gql } from "apollo-boost";
+import gql from "graphql-tag";
 import { Query } from "react-apollo";
 import Grid from "@material-ui/core/Grid";
 import ToggleButton from "@material-ui/lab/ToggleButton";

--- a/test/test-graphql-app/src/App.js
+++ b/test/test-graphql-app/src/App.js
@@ -15,6 +15,15 @@ const queries = {
         email
       }
     }
+  `,
+  GET_RECIPE: gql`
+    query getRecipe {
+      recipe(id: 1) {
+        id
+        title
+        ingredients
+      }
+    }
   `
 };
 
@@ -29,25 +38,41 @@ export const App = () => {
         onChange={(e, value) => setQuery(value)}
       >
         {Object.keys(queries).map(query => (
-          <ToggleButton key={query} id={query} value={query} children={query} />
+          <ToggleButton
+            key={query}
+            id={query}
+            value={[query]}
+            children={query}
+          />
         ))}
+        <ToggleButton
+          key="MULTIPLE"
+          id="MULTIPLE"
+          children="GET_USER+GET_RECIPE"
+          value={["GET_USER", "GET_RECIPE"]}
+        />
       </ToggleButtonGroup>
 
-      {currentQuery && (
-        <Card>
-          <CardContent>
-            <Query variables={{ id: 1 }} query={queries[currentQuery]}>
-              {({ loading, error, data }) => {
-                if (loading) return <div id="loading">Loading...</div>;
-                if (error)
-                  return <div id="error">Error :{JSON.stringify(error)} </div>;
+      {currentQuery &&
+        currentQuery.map(query => (
+          <Card>
+            <CardContent>
+              <Query query={queries[query]}>
+                {({ loading, error, data }) => {
+                  if (loading) return <div id="loading">Loading...</div>;
+                  if (error)
+                    return (
+                      <div id="error">Error :{JSON.stringify(error)} </div>
+                    );
 
-                return <div id="data"> {JSON.stringify(data)} </div>;
-              }}
-            </Query>
-          </CardContent>
-        </Card>
-      )}
+                  return (
+                    <div id={`${query}_RESULT`}> {JSON.stringify(data)} </div>
+                  );
+                }}
+              </Query>
+            </CardContent>
+          </Card>
+        ))}
     </Grid>
   );
 };

--- a/test/test-graphql-app/src/index.js
+++ b/test/test-graphql-app/src/index.js
@@ -5,10 +5,16 @@ import ApolloClient from "apollo-client";
 import { ApolloProvider } from "react-apollo";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { HttpLink } from "apollo-link-http";
+import { BatchHttpLink } from "apollo-link-batch-http";
 import { createPersistedQueryLink } from "apollo-link-persisted-queries";
 import { App } from "./App";
 
-const links = [new HttpLink({ uri: "/graphql" })];
+// Did we enable the Batch HTTP query link for this test?
+const httpLink = window.__USE_BATCH_HTTP_LINK
+  ? new BatchHttpLink({ uri: "/graphql" })
+  : new HttpLink({ uri: "/graphql" });
+
+const links = [httpLink];
 
 // Did we enable the Persisted Query link for this test?
 if (window.__USE_PERSISTED_QUERY_LINK) {

--- a/test/test-graphql-app/src/index.js
+++ b/test/test-graphql-app/src/index.js
@@ -1,10 +1,25 @@
 import React from "react";
 import { render } from "react-dom";
-import ApolloClient from "apollo-boost";
+import { ApolloLink } from "apollo-link";
+import ApolloClient from "apollo-client";
 import { ApolloProvider } from "react-apollo";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import { HttpLink } from "apollo-link-http";
+import { createPersistedQueryLink } from "apollo-link-persisted-queries";
 import { App } from "./App";
 
-const client = new ApolloClient({ uri: "/graphql" });
+const links = [new HttpLink({ uri: "/graphql" })];
+
+// Did we enable the Persisted Query link for this test?
+if (window.__USE_PERSISTED_QUERY_LINK) {
+  links.unshift(createPersistedQueryLink());
+}
+
+const client = new ApolloClient({
+  uri: "/graphql",
+  link: ApolloLink.from(links),
+  cache: new InMemoryCache()
+});
 
 const ApolloApp = AppComponent => (
   <ApolloProvider client={client}>

--- a/test/test-graphql-app/yarn.lock
+++ b/test/test-graphql-app/yarn.lock
@@ -1744,6 +1744,24 @@ apollo-client@^2.6.4:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
+apollo-link-batch-http@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch-http/-/apollo-link-batch-http-1.2.12.tgz#5c090b6300cf56695751d2246079c2f7d7b9c0f9"
+  integrity sha512-nyhogmcsVa24gpEw0vnHpquf2cANp/xMncs7F6cJzKBzDCvjp80yfhbrQSDqYocdQw4VjeDPCOoz4cqEH8r1TA==
+  dependencies:
+    apollo-link "^1.2.12"
+    apollo-link-batch "^1.1.13"
+    apollo-link-http-common "^0.2.14"
+    tslib "^1.9.3"
+
+apollo-link-batch@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch/-/apollo-link-batch-1.1.13.tgz#cc73cb59d994c41b1c657b597ed95393bc3bb2d6"
+  integrity sha512-Be/kQfY1KcXuSNk0MYdbFqOv8LtLkNgJcO96ynwu6geNiO2rPUi4rn8wjbc2YRwnJ3Qjy95YRbxr+O8gfpT/vw==
+  dependencies:
+    apollo-link "^1.2.12"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.14:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz#d3a195c12e00f4e311c417f121181dcc31f7d0c8"

--- a/test/test-graphql-app/yarn.lock
+++ b/test/test-graphql-app/yarn.lock
@@ -1711,21 +1711,6 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apollo-boost@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/apollo-boost/-/apollo-boost-0.4.4.tgz#7c278dac6cb6fa3f2f710c56baddc6e3ae730651"
-  integrity sha512-ASngBvazmp9xNxXfJ2InAzfDwz65o4lswlEPrWoN35scXmCz8Nz4k3CboUXbrcN/G0IExkRf/W7o9Rg0cjEBqg==
-  dependencies:
-    apollo-cache "^1.3.2"
-    apollo-cache-inmemory "^1.6.3"
-    apollo-client "^2.6.4"
-    apollo-link "^1.0.6"
-    apollo-link-error "^1.0.3"
-    apollo-link-http "^1.3.1"
-    graphql-tag "^2.4.2"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-
 apollo-cache-inmemory@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz#826861d20baca4abc45f7ca7a874105905b8525d"
@@ -1759,15 +1744,6 @@ apollo-client@^2.6.4:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-apollo-link-error@^1.0.3:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.11.tgz#7cd363179616fb90da7866cee85cb00ee45d2f3b"
-  integrity sha512-442DNqn3CNRikDaenMMkoDmCRmkoUx/XyUMlRTZBEFdTw3FYPQLsmDO3hzzC4doY5/BHcn9/jdYh9EeLx4HPsA==
-  dependencies:
-    apollo-link "^1.2.12"
-    apollo-link-http-common "^0.2.14"
-    tslib "^1.9.3"
-
 apollo-link-http-common@^0.2.14:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz#d3a195c12e00f4e311c417f121181dcc31f7d0c8"
@@ -1777,7 +1753,7 @@ apollo-link-http-common@^0.2.14:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
-apollo-link-http@^1.3.1:
+apollo-link-http@^1.5.15:
   version "1.5.15"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.15.tgz#106ab23bb8997bd55965d05855736d33119652cf"
   integrity sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==
@@ -1786,7 +1762,15 @@ apollo-link-http@^1.3.1:
     apollo-link-http-common "^0.2.14"
     tslib "^1.9.3"
 
-apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.12:
+apollo-link-persisted-queries@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-persisted-queries/-/apollo-link-persisted-queries-0.2.2.tgz#156597cb259b7bb56cf4e967a7be0312954f4591"
+  integrity sha512-YL7XBu/5QsSbbYaWUXgm87T2Hn/2AQZk5Wr8CLXGDr3Wl3E/TRhBhKgQQTly9xhaTi7jgBO+AeIyTH5wCBHA9w==
+  dependencies:
+    apollo-link "^1.2.1"
+    hash.js "^1.1.3"
+
+apollo-link@^1.0.0, apollo-link@^1.2.1, apollo-link@^1.2.12:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.12.tgz#014b514fba95f1945c38ad4c216f31bcfee68429"
   integrity sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==
@@ -4568,7 +4552,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
   integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
 
-graphql-tag@^2.4.2:
+graphql-tag@^2.10.1:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
@@ -4695,7 +4679,7 @@ hash-base@^3.0.0:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==


### PR DESCRIPTION
This pull request adds support for [apollo-link-batch-http](https://www.apollographql.com/docs/link/links/batch-http/) and [apollo-link-persisted-queries](https://github.com/apollographql/apollo-link-persisted-queries). If an array of queries is provided, it will resolve each one and then return the array of responses.

If the client tries to use persisted queries (which don't include the query itself in the payload), it will return a `PersistedQueryNotSupported` error so that the request is retried as a standard query.